### PR TITLE
new endpoint to allow for basic "street address" -to- "latitude and longitude" functionality

### DIFF
--- a/app/geocode.py
+++ b/app/geocode.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, Request
+
+router = APIRouter()
+
+
+@router.post("/geocode/")
+async def get_latitude_longitude(request: Request):
+    # request needs to be instantiated or you'll get a self error
+    """
+    Provide address with this format:
+    TODO - add address format
+    """
+
+    # await because async...
+    # request.json() retrieves the info that is being posted to this route
+    address_input = await request.json()
+
+    lat_long = {"latitude": 0, "longitude": 0}
+
+    # TODO - use a better default value than 0
+
+    # TODO - update lat + long with real values
+    return lat_long

--- a/app/geocode.py
+++ b/app/geocode.py
@@ -21,6 +21,9 @@ async def get_latitude_longitude(request: Request):
 
     All values should be a string
     if there is no address_line2, the value should still be an empty string
+
+    The output will be a JSON object with the following format:
+    {"latitude": , "longitude": }
     """
     # await because async...
     # request.json() retrieves the info that is being posted to this route

--- a/app/geocode.py
+++ b/app/geocode.py
@@ -1,4 +1,6 @@
 from fastapi import APIRouter, Request
+from geopy.geocoders import Nominatim
+import geopy
 
 router = APIRouter()
 
@@ -7,17 +9,47 @@ router = APIRouter()
 async def get_latitude_longitude(request: Request):
     # request needs to be instantiated or you'll get a self error
     """
-    Provide address with this format:
-    TODO - add address format
-    """
+    Please post an address as a JSON object with this exact format:
+    {
+        "address": "123 Gilman Dr W",
+        "address_line2": "",
+        "city": "Seattle",
+        "state": "WA",
+        "zip": "98119",
+        "country": "United States"
+    }
 
+    All values should be a string
+    if there is no address_line2, the value should still be an empty string
+    """
     # await because async...
     # request.json() retrieves the info that is being posted to this route
     address_input = await request.json()
-
+    # instantiate latitude + longitude dict
     lat_long = {"latitude": 0, "longitude": 0}
+    # instantiate geopy locator using user_agent from previous cohort
+    locator = Nominatim(user_agent='DS API - Family Promise')
+    # address string
+    address_string = "".join(
+        line + " "
+        for line in address_input.values()
+        if type(line) == str and line != ""
+    )
+    # ensure the provided address is properly recognized
+    if type(locator.geocode(address_string)) == geopy.location.Location:
+        # update latitude and longitude with real values
+        lat_long["latitude"] = locator.geocode(address_string).latitude
+        lat_long["longitude"] = locator.geocode(address_string).longitude
+    else:
+        # TODO - use better default values than "0" when an address is invalid or missing
+        # possible ideas:
+        # latitude and longitude of zip code if available
+        # or
+        # simply avoid mapping points if there are no valid coordinates
+        # and have an additional section on the map visualization for unmapped services
+        #
+        # and if all else fails, and we still *need* numbers that aren't 0...
+        # use "headquarters" or some other default point determined by stakeholder
+        None
 
-    # TODO - use a better default value than 0
-
-    # TODO - update lat + long with real values
     return lat_long

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app import db, ml, viz, eligibility, metrics
+from app import db, ml, viz, eligibility, metrics, geocode
 
 
 description = """
@@ -26,6 +26,7 @@ app.include_router(ml.router, tags=['Machine Learning'])
 app.include_router(viz.router, tags=['Visualizations'])
 app.include_router(eligibility.router, tags=['Eligibility'])
 app.include_router(metrics.router, tags=['Metrics'])
+app.include_router(geocode.router, tags=['Geocode'])
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
# Description

Geocode endpoint! This pull request adds the basic functionality of returning the latitude and longitude of a given address using geopy. Please watch this video to learn more and to see how to use the new endpoint: [Video](https://youtu.be/wPjsyrQzROg)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change status

- [x] Complete, but not tested (may need new tests)

# How Has This Been Tested?

The functionality of this new endpoint has been tested using postman. Please refer to the video if you'd like to see working.

# Checklist:

- [x] I have pulled from master before submitting this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer (the peer review to approve a PR counts.  The reviewer must download and test the code)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
